### PR TITLE
Clarify design-credit backfill failure messaging

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -150,6 +150,7 @@ function humanizeBackfillSkipReason(reason: string): string {
   if (trimmed === 'disabled') return 'Auto-backfill is disabled by server configuration.';
   if (trimmed === 'cooldown_active') return 'Auto-backfill cooldown is active. Try again shortly.';
   if (trimmed === 'unsupported_role') return 'Auto-backfill is not enabled for this credit role yet.';
+  if (trimmed === 'discogs_insufficient_evidence') return 'Discogs truth backfill ran, but not enough verified credit evidence was found yet.';
   if (trimmed.startsWith('error:')) return `Auto-backfill failed: ${trimmed.slice(6)}`;
   return `Auto-backfill skipped: ${trimmed}`;
 }

--- a/server/src/services/gemini.ts
+++ b/server/src/services/gemini.ts
@@ -2931,7 +2931,9 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
           }
         }
       } else if (verification && !canUseMusicBrainz) {
-        verification.backfill_skipped_reason = 'unsupported_role';
+        verification.backfill_skipped_reason = canUseTruthCredit
+          ? 'discogs_insufficient_evidence'
+          : 'unsupported_role';
       }
     }
   }


### PR DESCRIPTION
## What changed
- Updated server verification reason handling for design-credit prompts:
  - when MusicBrainz is not applicable but Discogs truth backfill was attempted and still insufficient, use `discogs_insufficient_evidence` instead of `unsupported_role`
- Added client-side humanized message for that new reason:
  - "Discogs truth backfill ran, but not enough verified credit evidence was found yet."

## Why
- `unsupported_role` was misleading for design-credit prompts where role is supported via Discogs but evidence can still be too sparse
- clearer messaging helps users understand what happened and what to try next

## Validation
- server: `npm run build`
- client: `npm run build`