### PR TITLE
Improve Spotify auth diagnostics and localhost cookie guidance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -896,12 +896,19 @@ function PlaylistPage() {
 
   useEffect(() => {
     const spotify = searchParams.get('spotify');
+    const spotifyReason = searchParams.get('spotify_reason');
     if (spotify === 'connected') {
       setSpotifyState('success');
       setSpotifyMessage('Spotify connected. You can now save this playlist.');
     } else if (spotify === 'auth_failed') {
       setSpotifyState('error');
-      setSpotifyMessage('Spotify authentication failed. Please try again.');
+      if (spotifyReason === 'missing_state_cookie' || spotifyReason === 'state_mismatch') {
+        setSpotifyMessage('Spotify authentication failed because callback cookies were missing. Open the app via http://localhost:5173 (not 127.0.0.1) and try again.');
+      } else if (spotifyReason?.startsWith('token_exchange_failed')) {
+        setSpotifyMessage('Spotify authentication failed during token exchange. Check SPOTIFY_REDIRECT_URI in your server .env and Spotify app settings.');
+      } else {
+        setSpotifyMessage('Spotify authentication failed. Please try again.');
+      }
     }
   }, [searchParams]);
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: '127.0.0.1',
+    host: 'localhost',
     port: 5173,
     proxy: {
       '/api': {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -457,10 +457,27 @@ app.get('/api/spotify/callback', async (req, res) => {
   const stateFromQuery = String(req.query.state || '');
   const code = String(req.query.code || '');
   const returnTo = cookies.spotify_return_to || '/';
+  const redirectWithSpotifyStatus = (status: 'connected' | 'auth_failed', reason?: string) => {
+    const params = new URLSearchParams({ spotify: status });
+    if (reason && reason.trim().length > 0) params.set('spotify_reason', reason.trim());
+    res.redirect(`${config.frontendUrl}${returnTo}?${params.toString()}`);
+  };
 
-  if (!code || !stateFromCookie || stateFromCookie !== stateFromQuery) {
+  if (!code) {
     res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
-    res.redirect(`${config.frontendUrl}${returnTo}?spotify=auth_failed`);
+    redirectWithSpotifyStatus('auth_failed', 'missing_code');
+    return;
+  }
+
+  if (!stateFromCookie) {
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
+    redirectWithSpotifyStatus('auth_failed', 'missing_state_cookie');
+    return;
+  }
+
+  if (stateFromCookie !== stateFromQuery) {
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
+    redirectWithSpotifyStatus('auth_failed', 'state_mismatch');
     return;
   }
 
@@ -483,7 +500,8 @@ app.get('/api/spotify/callback', async (req, res) => {
     console.log('[spotify-auth] token source: authorization_code flow');
     if (!tokenResponse.ok || !tokenData.access_token || !tokenData.expires_in) {
       res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
-      res.redirect(`${config.frontendUrl}${returnTo}?spotify=auth_failed`);
+      const reason = tokenData.error ? `token_exchange_failed:${tokenData.error}` : 'token_exchange_failed';
+      redirectWithSpotifyStatus('auth_failed', reason);
       return;
     }
 
@@ -496,10 +514,10 @@ app.get('/api/spotify/callback', async (req, res) => {
       clearCookie('spotify_return_to'),
     ]);
 
-    res.redirect(`${config.frontendUrl}${returnTo}?spotify=connected`);
+    redirectWithSpotifyStatus('connected');
   } catch {
     res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
-    res.redirect(`${config.frontendUrl}${returnTo}?spotify=auth_failed`);
+    redirectWithSpotifyStatus('auth_failed', 'callback_exception');
   }
 });
 


### PR DESCRIPTION
## What changed
- Improved Spotify callback error handling to return specific auth reasons via query params:
  - `missing_code`
  - `missing_state_cookie`
  - `state_mismatch`
  - `token_exchange_failed`
  - `callback_exception`
- Updated client Spotify error messaging to show actionable guidance based on auth reason
- Added explicit localhost guidance in UI for cookie/state failures
- Updated Vite dev host from `127.0.0.1` to `localhost` to reduce callback cookie mismatch issues

## Why
- Users were seeing a generic "Spotify authentication failed" message without enough context
- A common local-dev issue is mixing `127.0.0.1` and `localhost`, which can break OAuth state cookie validation
- Better diagnostics make failures understandable and faster to fix

## Validation
- server: `npm run build`
- client: `npm run build`
- restarted local dev server and client, then retested Spotify auth flow entry
