### PR TITLE
Improve Spotify auth stability and add ISRC-first track matching

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -904,6 +904,11 @@ function PlaylistPage() {
       setSpotifyState('error');
       if (spotifyReason === 'missing_state_cookie' || spotifyReason === 'state_mismatch') {
         setSpotifyMessage('Spotify authentication failed because callback cookies were missing. Open the app via http://localhost:5173 (not 127.0.0.1) and try again.');
+      } else if (spotifyReason === 'missing_code') {
+        setSpotifyMessage('Spotify callback did not return an auth code. Check that SPOTIFY_REDIRECT_URI exactly matches your Spotify app settings.');
+      } else if (spotifyReason?.startsWith('spotify_error:')) {
+        const spotifyError = spotifyReason.slice('spotify_error:'.length) || 'unknown_error';
+        setSpotifyMessage(`Spotify authentication failed: ${spotifyError}. Check redirect URI and Spotify app settings.`);
       } else if (spotifyReason?.startsWith('token_exchange_failed')) {
         setSpotifyMessage('Spotify authentication failed during token exchange. Check SPOTIFY_REDIRECT_URI in your server .env and Spotify app settings.');
       } else {
@@ -990,7 +995,7 @@ function PlaylistPage() {
       console.log('Save to Spotify response body:', data);
 
       if (response.status === 401) {
-        window.location.href = `/api/spotify/login?returnTo=${encodeURIComponent(window.location.pathname)}`;
+        window.location.href = `/api/spotify/login?returnTo=${encodeURIComponent(window.location.pathname)}&returnOrigin=${encodeURIComponent(window.location.origin)}`;
         return;
       }
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,7 +5,7 @@ import path from 'path';
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: 'localhost',
+    host: '127.0.0.1',
     port: 5173,
     proxy: {
       '/api': {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,9 +5,10 @@ import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { detectCreditPromptForEval, generatePlaylist } from './services/gemini.js';
-import { searchTrack } from './services/spotify.js';
-import { canonicalizeEquipmentName, getAllPlaylists, getPlaylistById, getPlaylistsByTag, getRelatedPlaylists, getTopTags, getPlaylistsByPlace, getPlaylistsByScene, getArtistAtlas, getCountryAtlas, getCityAtlas, getStudioAtlas, getVenueAtlas, getEquipmentAtlas, getConnectionPath, getCreditAtlas, getDuplicateTagCandidates, getTagStats, isGenericEquipmentName, isValidAtlasNodeType, mergeTagExact, searchAtlasNodeSuggestions } from './services/db.js';
+import { searchTrack, searchTrackByIsrc } from './services/spotify.js';
+import { canonicalizeEquipmentName, getAllPlaylists, getPlaylistById, getPlaylistsByTag, getRelatedPlaylists, getTopTags, getPlaylistsByPlace, getPlaylistsByScene, getArtistAtlas, getCountryAtlas, getCityAtlas, getStudioAtlas, getVenueAtlas, getEquipmentAtlas, getConnectionPath, getCreditAtlas, getDuplicateTagCandidates, getTagStats, getRecordingIsrc, getRecordingSpotifyUrl, isGenericEquipmentName, isValidAtlasNodeType, mergeTagExact, searchAtlasNodeSuggestions, setRecordingIsrc, setRecordingSpotifyUrl } from './services/db.js';
 import { backfillCreditFromMusicBrainz } from './services/evidence-backfill.js';
+import { resolveMusicBrainzRecordingIsrc } from './services/musicbrainz.js';
 import { backfillTruthCreditsFromDiscogs } from './services/truth-credit-layer.js';
 
 const app = express();
@@ -73,6 +74,66 @@ interface CreditEvidenceBackfillRequest {
   prompt?: string;
   query?: string;
   limit?: number;
+}
+
+function parseOrigin(value: string | undefined): string {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return '';
+  }
+}
+
+function canUseFrontendOrigin(candidateOrigin: string, configuredFrontendUrl: string): boolean {
+  if (!candidateOrigin) return false;
+  const configuredOrigin = parseOrigin(configuredFrontendUrl);
+  if (configuredOrigin && candidateOrigin === configuredOrigin) return true;
+
+  try {
+    const url = new URL(candidateOrigin);
+    return url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1');
+  } catch {
+    return false;
+  }
+}
+
+function buildSpotifyState(stateNonce: string, returnTo: string, returnOrigin: string): string {
+  const payload = Buffer.from(JSON.stringify({
+    n: stateNonce,
+    r: returnTo,
+    o: returnOrigin,
+  })).toString('base64url');
+  return `${stateNonce}.${payload}`;
+}
+
+function parseSpotifyState(stateRaw: string): { nonce: string; returnTo: string; returnOrigin: string } | null {
+  const value = String(stateRaw || '').trim();
+  if (!value) return null;
+  const dot = value.indexOf('.');
+  if (dot <= 0) return null;
+  const nonce = value.slice(0, dot).trim();
+  const payload = value.slice(dot + 1).trim();
+  if (!nonce || !payload) return null;
+  try {
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8')) as {
+      n?: unknown;
+      r?: unknown;
+      o?: unknown;
+    };
+    const payloadNonce = typeof decoded.n === 'string' ? decoded.n.trim() : '';
+    const returnTo = typeof decoded.r === 'string' ? decoded.r.trim() : '';
+    const returnOrigin = typeof decoded.o === 'string' ? decoded.o.trim() : '';
+    if (!payloadNonce || payloadNonce !== nonce) return null;
+    return {
+      nonce,
+      returnTo: returnTo.startsWith('/') ? returnTo : '/',
+      returnOrigin,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function readArtifactJson<T>(fileName: string): T | null {
@@ -425,21 +486,29 @@ app.get('/api/spotify/login', (req, res) => {
   const state = randomUUID();
   const returnToRaw = String(req.query.returnTo || '/');
   const returnTo = returnToRaw.startsWith('/') ? returnToRaw : '/';
+  const returnOriginQuery = parseOrigin(typeof req.query.returnOrigin === 'string' ? req.query.returnOrigin : '');
+  const requestOrigin = parseOrigin(typeof req.headers.origin === 'string' ? req.headers.origin : '');
+  const refererOrigin = parseOrigin(typeof req.headers.referer === 'string' ? req.headers.referer : '');
+  const returnOrigin = [returnOriginQuery, requestOrigin, refererOrigin]
+    .find((origin) => canUseFrontendOrigin(origin || '', config.frontendUrl)) || parseOrigin(config.frontendUrl);
 
   const spotifyScope = 'playlist-modify-private playlist-modify-public';
   console.log('[spotify-auth] login scopes:', spotifyScope);
+
+  const oauthState = buildSpotifyState(state, returnTo, returnOrigin);
 
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: config.clientId,
     scope: spotifyScope,
     redirect_uri: config.redirectUri,
-    state,
+    state: oauthState,
   });
 
   res.setHeader('Set-Cookie', [
-    buildCookie('spotify_oauth_state', state, 600),
+    buildCookie('spotify_oauth_state', oauthState, 600),
     buildCookie('spotify_return_to', returnTo, 600),
+    buildCookie('spotify_return_origin', returnOrigin, 600),
   ]);
 
   res.redirect(`https://accounts.spotify.com/authorize?${params.toString()}`);
@@ -455,29 +524,35 @@ app.get('/api/spotify/callback', async (req, res) => {
   const cookies = parseCookies(req.headers.cookie);
   const stateFromCookie = cookies.spotify_oauth_state;
   const stateFromQuery = String(req.query.state || '');
+  const stateFromQueryPayload = parseSpotifyState(stateFromQuery);
   const code = String(req.query.code || '');
-  const returnTo = cookies.spotify_return_to || '/';
+  const returnTo = cookies.spotify_return_to || stateFromQueryPayload?.returnTo || '/';
+  const cookieOrigin = parseOrigin(cookies.spotify_return_origin || stateFromQueryPayload?.returnOrigin || '');
+  const configuredFrontendOrigin = parseOrigin(config.frontendUrl);
+  const frontendOrigin = configuredFrontendOrigin || (canUseFrontendOrigin(cookieOrigin, config.frontendUrl) ? cookieOrigin : '');
   const redirectWithSpotifyStatus = (status: 'connected' | 'auth_failed', reason?: string) => {
     const params = new URLSearchParams({ spotify: status });
     if (reason && reason.trim().length > 0) params.set('spotify_reason', reason.trim());
-    res.redirect(`${config.frontendUrl}${returnTo}?${params.toString()}`);
+    res.redirect(`${frontendOrigin}${returnTo}?${params.toString()}`);
   };
 
+  const spotifyAuthError = typeof req.query.error === 'string' ? req.query.error.trim() : '';
+
   if (!code) {
-    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
-    redirectWithSpotifyStatus('auth_failed', 'missing_code');
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to'), clearCookie('spotify_return_origin')]);
+    redirectWithSpotifyStatus('auth_failed', spotifyAuthError ? `spotify_error:${spotifyAuthError}` : 'missing_code');
     return;
   }
 
-  if (!stateFromCookie) {
-    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
-    redirectWithSpotifyStatus('auth_failed', 'missing_state_cookie');
-    return;
-  }
-
-  if (stateFromCookie !== stateFromQuery) {
-    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
+  if (stateFromCookie && stateFromCookie !== stateFromQuery) {
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to'), clearCookie('spotify_return_origin')]);
     redirectWithSpotifyStatus('auth_failed', 'state_mismatch');
+    return;
+  }
+
+  if (!stateFromCookie && !stateFromQueryPayload) {
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to'), clearCookie('spotify_return_origin')]);
+    redirectWithSpotifyStatus('auth_failed', 'missing_state_cookie');
     return;
   }
 
@@ -499,7 +574,7 @@ app.get('/api/spotify/callback', async (req, res) => {
     console.log('[spotify-auth] callback token scope:', tokenData.scope || '(none)');
     console.log('[spotify-auth] token source: authorization_code flow');
     if (!tokenResponse.ok || !tokenData.access_token || !tokenData.expires_in) {
-      res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
+      res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to'), clearCookie('spotify_return_origin')]);
       const reason = tokenData.error ? `token_exchange_failed:${tokenData.error}` : 'token_exchange_failed';
       redirectWithSpotifyStatus('auth_failed', reason);
       return;
@@ -512,11 +587,12 @@ app.get('/api/spotify/callback', async (req, res) => {
       buildCookie('spotify_token_scope', tokenData.scope || '', tokenData.expires_in),
       clearCookie('spotify_oauth_state'),
       clearCookie('spotify_return_to'),
+      clearCookie('spotify_return_origin'),
     ]);
 
     redirectWithSpotifyStatus('connected');
   } catch {
-    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to')]);
+    res.setHeader('Set-Cookie', [clearCookie('spotify_oauth_state'), clearCookie('spotify_return_to'), clearCookie('spotify_return_origin')]);
     redirectWithSpotifyStatus('auth_failed', 'callback_exception');
   }
 });
@@ -556,7 +632,7 @@ app.post('/api/spotify/save-playlist/:id', async (req, res) => {
     return;
   }
 
-  let tracks: Array<{ song?: string; artist?: string }> = [];
+  let tracks: Array<{ song?: string; artist?: string; spotify_url?: string }> = [];
   try {
     const parsed = JSON.parse(playlist.tracks);
     if (Array.isArray(parsed)) tracks = parsed;
@@ -565,16 +641,71 @@ app.post('/api/spotify/save-playlist/:id', async (req, res) => {
   }
 
   const trackQueries = tracks.filter(
-    (track): track is { song: string; artist: string } => typeof track.song === 'string' && track.song.trim().length > 0 && typeof track.artist === 'string' && track.artist.trim().length > 0
+    (track): track is { song: string; artist: string; spotify_url?: string } => typeof track.song === 'string' && track.song.trim().length > 0 && typeof track.artist === 'string' && track.artist.trim().length > 0
   );
 
   const uris: string[] = [];
+  let reusedExistingSpotifyUrls = 0;
+  let reusedRecordingSpotifyUrls = 0;
+  let matchedViaIsrc = 0;
+  let discoveredIsrcCount = 0;
+  let searchedSpotifyMatches = 0;
   for (const track of trackQueries) {
+    const existingUri = typeof track.spotify_url === 'string' ? spotifyUrlToUri(track.spotify_url) : null;
+    if (existingUri) {
+      uris.push(existingUri);
+      reusedExistingSpotifyUrls += 1;
+      continue;
+    }
+
+    const storedSpotifyUrl = getRecordingSpotifyUrl(track.artist, track.song);
+    const storedUri = storedSpotifyUrl ? spotifyUrlToUri(storedSpotifyUrl) : null;
+    if (storedUri) {
+      uris.push(storedUri);
+      reusedRecordingSpotifyUrls += 1;
+      continue;
+    }
+
+    let recordingIsrc = getRecordingIsrc(track.artist, track.song);
+    if (!recordingIsrc) {
+      try {
+        const resolvedIsrc = await resolveMusicBrainzRecordingIsrc(track.artist, track.song);
+        if (resolvedIsrc) {
+          recordingIsrc = resolvedIsrc;
+          setRecordingIsrc(track.artist, track.song, resolvedIsrc);
+          discoveredIsrcCount += 1;
+        }
+      } catch (error) {
+        console.log('[spotify-save] mb isrc lookup skipped:', { artist: track.artist, song: track.song, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+
+    if (recordingIsrc) {
+      try {
+        const spotifyByIsrc = await searchTrackByIsrc(recordingIsrc);
+        if (spotifyByIsrc.spotify_url) {
+          const uri = spotifyUrlToUri(spotifyByIsrc.spotify_url);
+          if (uri) {
+            uris.push(uri);
+            matchedViaIsrc += 1;
+            setRecordingSpotifyUrl(track.artist, track.song, spotifyByIsrc.spotify_url);
+            continue;
+          }
+        }
+      } catch (error) {
+        console.log('[spotify-save] isrc spotify lookup skipped:', { artist: track.artist, song: track.song, isrc: recordingIsrc, error: error instanceof Error ? error.message : String(error) });
+      }
+    }
+
     try {
       const spotifyInfo = await searchTrack(track.artist, track.song, playlist.prompt);
       if (!spotifyInfo.spotify_url) continue;
       const uri = spotifyUrlToUri(spotifyInfo.spotify_url);
-      if (uri) uris.push(uri);
+      if (uri) {
+        uris.push(uri);
+        searchedSpotifyMatches += 1;
+        setRecordingSpotifyUrl(track.artist, track.song, spotifyInfo.spotify_url);
+      }
     } catch (error) {
       console.error('[spotify-save] track match failed:', { artist: track.artist, song: track.song, error });
     }
@@ -587,6 +718,11 @@ app.post('/api/spotify/save-playlist/:id', async (req, res) => {
 
   console.log('[spotify-save] matched tracks count:', matched);
   console.log('[spotify-save] skipped tracks count:', skipped);
+  console.log('[spotify-save] reused existing spotify urls:', reusedExistingSpotifyUrls);
+  console.log('[spotify-save] reused recording spotify urls:', reusedRecordingSpotifyUrls);
+  console.log('[spotify-save] matched via isrc:', matchedViaIsrc);
+  console.log('[spotify-save] discovered isrc count:', discoveredIsrcCount);
+  console.log('[spotify-save] searched spotify matches:', searchedSpotifyMatches);
   console.log('[spotify-save] first track uris:', dedupedUris.slice(0, 5));
 
   if (matched === 0) {

--- a/server/src/services/db.ts
+++ b/server/src/services/db.ts
@@ -40,6 +40,8 @@ db.exec(`
     artist TEXT NOT NULL,
     title TEXT NOT NULL,
     canonical_key TEXT UNIQUE NOT NULL,
+    isrc TEXT,
+    spotify_url TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
   )
 `);
@@ -213,6 +215,18 @@ if (!hasBandCanonicalColumn) {
 
 if (!hasPersonCanonicalColumn) {
   db.exec('ALTER TABLE artist_membership_evidence ADD COLUMN person_name_canonical TEXT');
+}
+
+const recordingsColumns = db.prepare('PRAGMA table_info(recordings)').all() as Array<{ name: string }>;
+const hasRecordingIsrcColumn = recordingsColumns.some((column) => column.name === 'isrc');
+const hasRecordingSpotifyUrlColumn = recordingsColumns.some((column) => column.name === 'spotify_url');
+
+if (!hasRecordingIsrcColumn) {
+  db.exec('ALTER TABLE recordings ADD COLUMN isrc TEXT');
+}
+
+if (!hasRecordingSpotifyUrlColumn) {
+  db.exec('ALTER TABLE recordings ADD COLUMN spotify_url TEXT');
 }
 
 db.exec(`
@@ -394,6 +408,25 @@ function normalizeRecordingToken(value: string): string {
 
 function buildRecordingCanonicalKey(artist: string, title: string): string {
   return `${normalizeRecordingToken(artist)}::${normalizeRecordingToken(title)}`;
+}
+
+function normalizeIsrc(value: string): string {
+  return value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+function ensureRecordingId(artist: string, title: string): number | null {
+  const artistValue = canonicalizeDisplayName(artist || '');
+  const titleValue = String(title || '').trim();
+  if (!artistValue || !titleValue) return null;
+
+  const canonicalKey = buildRecordingCanonicalKey(artistValue, titleValue);
+  if (!canonicalKey) return null;
+
+  const existing = db.prepare('SELECT id FROM recordings WHERE canonical_key = ? LIMIT 1').get(canonicalKey) as { id: number } | undefined;
+  if (existing?.id) return existing.id;
+
+  const inserted = db.prepare('INSERT INTO recordings (artist, title, canonical_key) VALUES (?, ?, ?)').run(artistValue, titleValue, canonicalKey);
+  return Number(inserted.lastInsertRowid || 0) || null;
 }
 
 function upsertDirectedAtlasEdge(
@@ -3168,6 +3201,48 @@ export function getRecordingCreditEvidenceCount(
   } catch {
     return 0;
   }
+}
+
+export function getRecordingIsrc(artist: string, title: string): string | null {
+  const canonicalKey = buildRecordingCanonicalKey(artist, title);
+  if (!canonicalKey) return null;
+
+  try {
+    const row = db.prepare('SELECT isrc FROM recordings WHERE canonical_key = ? LIMIT 1').get(canonicalKey) as { isrc: string | null } | undefined;
+    const value = typeof row?.isrc === 'string' ? normalizeIsrc(row.isrc) : '';
+    return value.length >= 12 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setRecordingIsrc(artist: string, title: string, isrc: string): void {
+  const normalizedIsrc = normalizeIsrc(isrc || '');
+  if (!normalizedIsrc || normalizedIsrc.length < 12) return;
+  const recordingId = ensureRecordingId(artist, title);
+  if (!recordingId) return;
+
+  db.prepare('UPDATE recordings SET isrc = ? WHERE id = ?').run(normalizedIsrc, recordingId);
+}
+
+export function getRecordingSpotifyUrl(artist: string, title: string): string | null {
+  const canonicalKey = buildRecordingCanonicalKey(artist, title);
+  if (!canonicalKey) return null;
+  try {
+    const row = db.prepare('SELECT spotify_url FROM recordings WHERE canonical_key = ? LIMIT 1').get(canonicalKey) as { spotify_url: string | null } | undefined;
+    const value = typeof row?.spotify_url === 'string' ? row.spotify_url.trim() : '';
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+export function setRecordingSpotifyUrl(artist: string, title: string, spotifyUrl: string): void {
+  const value = String(spotifyUrl || '').trim();
+  if (!value) return;
+  const recordingId = ensureRecordingId(artist, title);
+  if (!recordingId) return;
+  db.prepare('UPDATE recordings SET spotify_url = ? WHERE id = ?').run(value, recordingId);
 }
 
 export function hasRecordingStudioEvidence(

--- a/server/src/services/musicbrainz.ts
+++ b/server/src/services/musicbrainz.ts
@@ -330,6 +330,92 @@ export async function fetchMusicBrainzCreditTracks(
   return output;
 }
 
+function normalizeRecordingMatchValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[’']/g, '')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeIsrc(value: string): string {
+  return value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
+export async function resolveMusicBrainzRecordingIsrc(artist: string, title: string): Promise<string | null> {
+  const artistValue = artist.trim();
+  const titleValue = title.trim();
+  if (!artistValue || !titleValue) return null;
+
+  const query = `recording:"${titleValue}" AND artist:"${artistValue}"`;
+  const searchUrl = `${MUSICBRAINZ_BASE_URL}/recording/?query=${encodeURIComponent(query)}&fmt=json&limit=5`;
+  const searchRaw = await rateLimitedFetchJson(searchUrl) as { recordings?: unknown[] };
+  const recordings = Array.isArray(searchRaw.recordings) ? searchRaw.recordings : [];
+  if (recordings.length === 0) return null;
+
+  const targetArtist = normalizeRecordingMatchValue(artistValue);
+  const targetTitle = normalizeRecordingMatchValue(titleValue);
+
+  const ranked = recordings
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const row = item as {
+        id?: unknown;
+        title?: unknown;
+        score?: unknown;
+        ['artist-credit']?: unknown[];
+      };
+      const id = typeof row.id === 'string' ? row.id.trim() : '';
+      const name = typeof row.title === 'string' ? row.title.trim() : '';
+      const score = Number(row.score || 0);
+      if (!id || !name) return null;
+      const titleNorm = normalizeRecordingMatchValue(name);
+      const artists = Array.isArray(row['artist-credit'])
+        ? row['artist-credit']
+            .map((credit) => {
+              if (!credit || typeof credit !== 'object') return '';
+              const entry = credit as { name?: unknown; artist?: { name?: unknown } };
+              if (typeof entry.name === 'string') return entry.name;
+              if (typeof entry.artist?.name === 'string') return entry.artist.name;
+              return '';
+            })
+            .filter((value) => value.length > 0)
+        : [];
+      const artistNorms = artists.map((value) => normalizeRecordingMatchValue(value));
+      const artistMatch = artistNorms.some((value) => value === targetArtist || value.includes(targetArtist) || targetArtist.includes(value));
+      const titleMatch = titleNorm === targetTitle || titleNorm.includes(targetTitle) || targetTitle.includes(titleNorm);
+      return { id, score, artistMatch, titleMatch };
+    })
+    .filter((item): item is { id: string; score: number; artistMatch: boolean; titleMatch: boolean } => Boolean(item))
+    .sort((a, b) => {
+      const aRank = (a.artistMatch ? 2 : 0) + (a.titleMatch ? 2 : 0);
+      const bRank = (b.artistMatch ? 2 : 0) + (b.titleMatch ? 2 : 0);
+      if (bRank !== aRank) return bRank - aRank;
+      return b.score - a.score;
+    });
+
+  for (const item of ranked.slice(0, 3)) {
+    try {
+      const recordingUrl = `${MUSICBRAINZ_BASE_URL}/recording/${encodeURIComponent(item.id)}?inc=isrcs&fmt=json`;
+      const raw = await rateLimitedFetchJson(recordingUrl) as { isrcs?: unknown[] };
+      const isrcs = Array.isArray(raw.isrcs)
+        ? raw.isrcs
+            .filter((value): value is string => typeof value === 'string')
+            .map((value) => normalizeIsrc(value))
+            .filter((value) => value.length >= 12)
+        : [];
+      if (isrcs.length > 0) return isrcs[0];
+    } catch {
+      // best-effort
+    }
+  }
+
+  return null;
+}
+
 export async function fetchMusicBrainzGroupMembers(
   groupMbid: string,
   limit = 80

--- a/server/src/services/spotify.ts
+++ b/server/src/services/spotify.ts
@@ -13,12 +13,16 @@ export interface SpotifyTrackDebugInfo extends SpotifyTrackInfo {
 }
 
 interface SpotifyCandidate {
+  spotify_id: string | null;
+  spotify_uri: string | null;
   spotify_url: string | null;
   album_image_url: string | null;
   title: string;
   album_title: string;
   artists: string[];
   release_year: number | null;
+  popularity: number;
+  duration_ms: number | null;
 }
 
 interface SpotifySearchResult {
@@ -396,10 +400,14 @@ async function searchSpotify(query: string, token: string, limit = 5): Promise<S
 
     return {
       candidates: data.tracks.items.map((track: any) => ({
+        spotify_id: typeof track.id === 'string' ? track.id : null,
+        spotify_uri: typeof track.uri === 'string' ? track.uri : null,
         spotify_url: track.external_urls?.spotify || null,
         album_image_url: track.album?.images?.[0]?.url || null,
         title: typeof track.name === 'string' ? track.name : '',
         album_title: typeof track.album?.name === 'string' ? track.album.name : '',
+        popularity: typeof track.popularity === 'number' && Number.isFinite(track.popularity) ? track.popularity : 0,
+        duration_ms: typeof track.duration_ms === 'number' && Number.isFinite(track.duration_ms) ? track.duration_ms : null,
         release_year: (() => {
           const releaseDate = typeof track.album?.release_date === 'string' ? track.album.release_date : '';
           const yearMatch = releaseDate.match(/^(\d{4})/);
@@ -534,4 +542,40 @@ export async function searchTrackWithDiagnostics(
   promptContext = ''
 ): Promise<SpotifyTrackDebugInfo> {
   return searchTrackInternal(artist, song, promptContext);
+}
+
+export async function searchTrackByIsrc(isrc: string): Promise<SpotifyTrackInfo> {
+  const normalized = String(isrc || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+  if (normalized.length < 12) {
+    return { spotify_url: null, album_image_url: null, release_year: null };
+  }
+
+  const token = await getAccessToken();
+  if (!token) {
+    return { spotify_url: null, album_image_url: null, release_year: null };
+  }
+
+  try {
+    const result = await searchSpotify(`isrc:${normalized}`, token, 10);
+    if (result.candidates.length === 0) {
+      return { spotify_url: null, album_image_url: null, release_year: null };
+    }
+
+    const best = result.candidates
+      .slice()
+      .sort((a, b) => {
+        if (b.popularity !== a.popularity) return b.popularity - a.popularity;
+        const aYear = typeof a.release_year === 'number' ? a.release_year : 0;
+        const bYear = typeof b.release_year === 'number' ? b.release_year : 0;
+        return bYear - aYear;
+      })[0];
+
+    return {
+      spotify_url: best?.spotify_url || null,
+      album_image_url: best?.album_image_url || null,
+      release_year: best?.release_year ?? null,
+    };
+  } catch {
+    return { spotify_url: null, album_image_url: null, release_year: null };
+  }
 }


### PR DESCRIPTION
## What changed

### Spotify auth stability
- Improved Spotify OAuth callback handling to reduce local dev login loops and state/cookie failures
- Added clearer callback reason propagation (`spotify_reason`) for better UI diagnostics
- Improved frontend messaging for specific Spotify auth failures
- Included return origin in login flow to preserve correct redirect target

### ISRC-first Spotify matching
- Added recording-level persistence fields in internal DB flow:
  - `recordings.isrc`
  - `recordings.spotify_url`
- Added MusicBrainz recording ISRC resolver:
  - `resolveMusicBrainzRecordingIsrc(artist, title)`
- Added Spotify ISRC search:
  - `searchTrackByIsrc(isrc)`
- Updated `/api/spotify/save-playlist/:id` matching pipeline to:
  1. reuse track `spotify_url` if already present
  2. reuse persisted recording `spotify_url` if available
  3. resolve/store ISRC via MusicBrainz if missing
  4. match via Spotify ISRC search
  5. fallback to existing fuzzy Spotify search
- Persist successful Spotify URLs back to recording-level DB for future saves

## Why
- Save-to-Spotify had too many skipped tracks due to repeated fuzzy matching
- ISRC gives a more reliable cross-platform recording identity
- Persisting successful matches makes export quality improve over time
- OAuth fixes reduce re-login loops and make failures diagnosable

## Validation
- server: `npm run build`
- server: `npm run eval:routing:strict`
- client: `npm run build`