### PR TITLE
Relax Spotify title matching for common version suffixes

### DIFF
--- a/server/src/services/spotify.ts
+++ b/server/src/services/spotify.ts
@@ -159,12 +159,29 @@ function validateCandidateMatch(
   const requestedTitle = normalizeTitleKey(song);
   const cleanedRequestedTitle = normalizeTitleKey(cleanSongTitle(song));
   const candidateTitle = normalizeTitleKey(candidate.title);
+  const hasAllowedVersionSuffix = (baseTitle: string): boolean => {
+    if (!baseTitle || candidateTitle.length <= baseTitle.length) return false;
+    if (!candidateTitle.startsWith(`${baseTitle} `)) return false;
+    const suffix = candidateTitle.slice(baseTitle.length).trim();
+    if (!suffix) return false;
+    const compactSuffix = suffix.replace(/^[-\s]+/, '').trim();
+    const tokenCount = compactSuffix.split(' ').filter(Boolean).length;
+    if (tokenCount === 0 || tokenCount > 8) return false;
+    return /\b(remaster(?:ed)?|mix|edit|version|mono|stereo|acoustic|instrumental|karaoke|live|session|demo|deluxe|expanded|anniversary|explicit|clean|single|take)\b/.test(compactSuffix);
+  };
+
   const hasRequestedPrefix = allowTitleSuffix
     && (
       (requestedTitle.length > 0 && (candidateTitle === requestedTitle || candidateTitle.startsWith(`${requestedTitle} `)))
       || (cleanedRequestedTitle.length > 0 && (candidateTitle === cleanedRequestedTitle || candidateTitle.startsWith(`${cleanedRequestedTitle} `)))
     );
-  const titleOk = candidateTitle === requestedTitle || candidateTitle === cleanedRequestedTitle || hasRequestedPrefix;
+  const hasVersionSuffixMatch =
+    (requestedTitle.length > 0 && hasAllowedVersionSuffix(requestedTitle))
+    || (cleanedRequestedTitle.length > 0 && hasAllowedVersionSuffix(cleanedRequestedTitle));
+  const titleOk = candidateTitle === requestedTitle
+    || candidateTitle === cleanedRequestedTitle
+    || hasRequestedPrefix
+    || hasVersionSuffixMatch;
   if (!titleOk) {
     return { ok: false, reason: 'title mismatch' };
   }


### PR DESCRIPTION
## What changed
- Updated Spotify candidate title validation to allow common version suffix matches when base title and artist match
- Added controlled suffix handling for tokens like:
  - remaster/remastered
  - mix/edit/version
  - mono/stereo
  - acoustic/instrumental/karaoke
  - live/session/demo
  - deluxe/expanded/anniversary
  - explicit/clean/single/take

## Why
- Many valid Spotify tracks include suffix variants even when they represent the intended song
- Previous strict title equality caused unnecessary skipped tracks in Save-to-Spotify
- This keeps artist validation strict while reducing false negatives on title variants

## Validation
- server: `npm run build`
- server: `npm run eval:routing:strict`