### PR TITLE
Tighten artist relatedness thresholds to prevent atlas leaks

### DIFF
--- a/server/src/services/db.ts
+++ b/server/src/services/db.ts
@@ -2632,9 +2632,8 @@ export function getArtistAtlas(artist: string): {
   const relatedArtists = Array.from(relatedArtistCounts.values())
     .filter(
       (item) => item.sharedMembershipEvidence >= 1
-        || item.edgeEvidence >= 2
-        || item.sharedCreditEvidence >= 1
-        || item.sharedStudioEvidence >= 2
+        || item.sharedCreditEvidence >= 2
+        || item.sharedStudioEvidence >= 3
     )
     .sort((a, b) => {
       const aShared = a.sharedCreditEvidence + a.sharedStudioEvidence;


### PR DESCRIPTION
## Summary

This PR fixes an atlas precision issue where unrelated artists could leak into `relatedArtists` (notably Beatles appearing in Pink Floyd atlas results).

- Tightens related-artist inclusion thresholds in `getArtistAtlas` (`server/src/services/db.ts`).
- Keeps strong, explicit relation signals (shared membership) while reducing weak/noisy associations.
- Prevents broad graph co-occurrence noise from surfacing as top related artists.

## Why

`eval:atlas:strict` was failing on:

- `artist_relatedartists_pink_floyd_no_beatles_leak`

with forbidden values in `relatedArtists`:
- `The Beatles`
- `Paul McCartney`

The previous thresholds were permissive enough for unrelated graph noise to pass.

## Validation

- `npm run eval:atlas:strict` ✅ (21/21)
- `npm run build` (server) ✅

`artist_relatedartists_pink_floyd_no_beatles_leak` now passes with:

- `David Gilmour`
- `Nick Mason`
- `Richard Wright`
- `Roger Waters`

## Scope

- Single-file change:
  - `server/src/services/db.ts`
- No API contract changes.
- No migration required.