### PR TITLE
make MusicBrainz primary source for studio evidence backfill

### DIFF
--- a/server/src/services/db.ts
+++ b/server/src/services/db.ts
@@ -3421,10 +3421,13 @@ export function hasRecordingStudioEvidence(
       ? 'INNER JOIN playlists p ON p.id = rse.source_playlist_id'
       : '';
     const trustedWhereClause = trustedOnly
-      ? 'AND p.prompt LIKE ?'
+      ? 'AND (p.prompt LIKE ? OR p.prompt LIKE ?)'
       : '';
     const params: Array<string> = [canonicalKey, normalizedStudio];
-    if (trustedOnly) params.push('[system] studio evidence backfill from discogs ::%');
+    if (trustedOnly) {
+      params.push('[system] studio evidence backfill from discogs ::%');
+      params.push('[system] studio evidence backfill from musicbrainz ::%');
+    }
 
     const row = db.prepare(`
       SELECT 1 AS matched
@@ -3457,10 +3460,13 @@ export function getTracksByRecordingStudioEvidence(
       ? 'INNER JOIN playlists p ON p.id = rse.source_playlist_id'
       : '';
     const trustedWhereClause = trustedOnly
-      ? 'AND p.prompt LIKE ?'
+      ? 'AND (p.prompt LIKE ? OR p.prompt LIKE ?)'
       : '';
     const params: Array<string | number> = [normalizedStudio];
-    if (trustedOnly) params.push('[system] studio evidence backfill from discogs ::%');
+    if (trustedOnly) {
+      params.push('[system] studio evidence backfill from discogs ::%');
+      params.push('[system] studio evidence backfill from musicbrainz ::%');
+    }
     params.push(safeLimit);
 
     const rows = db.prepare(`

--- a/server/src/services/evidence-backfill-studio.ts
+++ b/server/src/services/evidence-backfill-studio.ts
@@ -5,6 +5,7 @@ import {
   savePlaylist,
 } from './db.js';
 import { fetchDiscogsStudioTracksByArtistCatalog, fetchDiscogsStudioTracksByArtistHints, fetchDiscogsStudioTracksByLabel, isDiscogsConfigured, searchDiscogsStudioLabelId } from './discogs.js';
+import { fetchMusicBrainzStudioTracksByPlace, resolveMusicBrainzStudioPlace } from './musicbrainz.js';
 import { buildStudioCanonicalKey, canonicalizeDisplayName } from './normalize.js';
 import { resolveStudioIdentity, resolveStudioIdentityFromPrompt } from './studio-identity.js';
 
@@ -20,8 +21,11 @@ export interface StudioEvidenceBackfillParams {
 
 export interface StudioEvidenceBackfillResult {
   attempted: boolean;
+  source: 'discogs' | 'musicbrainz' | 'hybrid';
   studioName: string;
   studioIdentityKey?: string;
+  musicBrainzPlaceId?: string;
+  musicBrainzPlaceName?: string;
   discogsLabelId?: number;
   discogsLabelSource?: 'identity' | 'search';
   imported: number;
@@ -31,6 +35,17 @@ export interface StudioEvidenceBackfillResult {
   skippedInvalid: number;
   skippedReason?: string;
 }
+
+type StudioSeedTrack = {
+  artist: string;
+  title: string;
+  studioName: string;
+  releaseId: number;
+  releaseTitle: string;
+  sourceRef: string;
+  source: 'discogs' | 'musicbrainz';
+  recordedYear?: number;
+};
 
 function normalizeRecordingToken(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, ' ');
@@ -46,17 +61,96 @@ function normalizeLimit(limit: number | undefined): number {
   return Math.max(1, Math.min(400, Math.floor(parsed)));
 }
 
-function ensureSourcePlaylistId(studioName: string): number {
-  const sourcePrompt = `[system] studio evidence backfill from discogs :: ${studioName}`;
+function normalizeTrackKey(artist: string, title: string): string {
+  return `${artist.trim().toLowerCase()}::${title.trim().toLowerCase()}`;
+}
+
+function extractYear(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const match = value.match(/\b(19\d{2}|20\d{2})\b/);
+  if (!match) return null;
+  const year = Number(match[1]);
+  if (!Number.isFinite(year) || year < 1900 || year > 2099) return null;
+  return Math.floor(year);
+}
+
+function isVariantStudioTitle(title: string): boolean {
+  const value = title.toLowerCase();
+  return /\b(remix|mix|demo|instrumental|karaoke|take\s*\d+|take\b|alternate|alt\.|version|radio edit|extended|acoustic|live|rehearsal|dub|isolated|half[\s-]?mixed)\b/.test(value);
+}
+
+function isLikelySongRecording(artist: string, title: string): boolean {
+  if (!artist || !title) return false;
+  if (title.length > 90) return false;
+
+  const artistCommaCount = (artist.match(/,/g) || []).length;
+  if (artistCommaCount >= 2) return false;
+
+  const artistLower = artist.toLowerCase();
+  const titleLower = title.toLowerCase();
+  if (/\b(orchestra|symphony|philharmonic|choir|ensemble|quartet|quintet|conductor)\b/.test(artistLower)) return false;
+  if (/\b(op\.|opus|concerto|sonata|suite|movement|act\s+\d+|scene\s+\d+|recitativo|aria|overture)\b/.test(titleLower)) return false;
+  if (title.includes(':')) return false;
+
+  return true;
+}
+
+function countUniqueArtists(rows: Array<{ artist: string }>): number {
+  return new Set(rows.map((row) => row.artist.trim().toLowerCase()).filter(Boolean)).size;
+}
+
+function diversifyStudioSeedTracks<T extends { artist: string; title: string }>(tracks: T[], desired: number): T[] {
+  if (tracks.length <= 1 || desired <= 0) return tracks.slice(0, Math.max(0, desired));
+
+  const target = Math.min(desired, tracks.length);
+  const selected: T[] = [];
+  const selectedKeys = new Set<string>();
+  const artistCounts = new Map<string, number>();
+
+  const addPass = (artistCap: number): void => {
+    for (const track of tracks) {
+      if (selected.length >= target) return;
+      const key = normalizeTrackKey(track.artist, track.title);
+      if (!key || selectedKeys.has(key)) continue;
+      const artistKey = track.artist.trim().toLowerCase();
+      if (!artistKey) continue;
+      const count = artistCounts.get(artistKey) || 0;
+      if (count >= artistCap) continue;
+      selected.push(track);
+      selectedKeys.add(key);
+      artistCounts.set(artistKey, count + 1);
+    }
+  };
+
+  addPass(1);
+  if (selected.length < target) addPass(2);
+  if (selected.length < target) addPass(3);
+  if (selected.length < target) addPass(5);
+
+  if (selected.length < target) {
+    for (const track of tracks) {
+      if (selected.length >= target) break;
+      const key = normalizeTrackKey(track.artist, track.title);
+      if (!key || selectedKeys.has(key)) continue;
+      selected.push(track);
+      selectedKeys.add(key);
+    }
+  }
+
+  return selected;
+}
+
+function ensureSourcePlaylistId(studioName: string, source: 'discogs' | 'musicbrainz'): number {
+  const sourcePrompt = `[system] studio evidence backfill from ${source} :: ${studioName}`;
   const existing = getPlaylistByPrompt(sourcePrompt) || getPlaylistByCacheKey(sourcePrompt);
   if (existing) return existing.id;
 
   const created = savePlaylist(
     sourcePrompt,
     `System studio seed (${studioName})`,
-    'Synthetic playlist row used as source for Discogs studio evidence seeding.',
+    `Synthetic playlist row used as source for ${source === 'musicbrainz' ? 'MusicBrainz' : 'Discogs'} studio evidence seeding.`,
     '[]',
-    JSON.stringify(['system_seed', 'studio', 'discogs'])
+    JSON.stringify(['system_seed', 'studio', source])
   );
 
   return created.id;
@@ -68,13 +162,30 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
   const resolved = resolveStudioIdentity(inputStudio) || resolvedFromPrompt;
   const studioName = resolved?.primaryName || inputStudio;
   const studioIdentityKey = resolved?.key;
+  const acceptedStudioNames = Array.isArray(resolved?.acceptedStudioNames)
+    ? resolved.acceptedStudioNames
+    : [];
   let discogsLabelId = resolved?.discogsLabelId;
   let discogsLabelSource: 'identity' | 'search' | undefined = discogsLabelId ? 'identity' : undefined;
+  let musicBrainzPlaceId: string | undefined;
+  let musicBrainzPlaceName: string | undefined;
   const limit = normalizeLimit(params.limit);
+  const activeStartYear = typeof params.activeStartYear === 'number' ? params.activeStartYear : undefined;
+  const activeEndYear = typeof params.activeEndYear === 'number' ? params.activeEndYear : undefined;
+  const musicBrainzEnabled = process.env.ENABLE_STUDIO_MUSICBRAINZ_BACKFILL !== 'false';
+  const discogsEnabled = process.env.ENABLE_STUDIO_DISCOGS_BACKFILL !== 'false' && isDiscogsConfigured();
+  const artistHints = Array.isArray(params.artistHints)
+    ? Array.from(new Set(params.artistHints.map((value) => canonicalizeDisplayName(value || '')).filter((value) => value.length > 0))).slice(0, 12)
+    : [];
+
+  let attemptedMusicBrainz = false;
+  let attemptedDiscogs = false;
+  let studioTracks: StudioSeedTrack[] = [];
 
   if (!studioName) {
     return {
       attempted: false,
+      source: 'hybrid',
       studioName: '',
       imported: 0,
       insertedRecordings: 0,
@@ -85,99 +196,142 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
     };
   }
 
-  if (!isDiscogsConfigured()) {
-    return {
-      attempted: false,
-      studioName,
-      studioIdentityKey,
-      discogsLabelId,
-      discogsLabelSource,
-      imported: 0,
-      insertedRecordings: 0,
-      insertedEvidence: 0,
-      skippedExistingEvidence: 0,
-      skippedInvalid: 0,
-      skippedReason: 'missing_discogs_token',
-    };
-  }
+  if (musicBrainzEnabled) {
+    attemptedMusicBrainz = true;
+    try {
+      const preferredPlaceId = typeof resolved?.musicBrainzPlaceId === 'string' ? resolved.musicBrainzPlaceId.trim() : '';
+      const resolvedPlace = preferredPlaceId
+        ? { id: preferredPlaceId, name: studioName, score: 100, type: 'Studio', disambiguation: '' }
+        : await resolveMusicBrainzStudioPlace(studioName, acceptedStudioNames);
+      if (resolvedPlace) {
+        musicBrainzPlaceId = resolvedPlace.id;
+        musicBrainzPlaceName = resolvedPlace.name;
+        const mbTracks = await fetchMusicBrainzStudioTracksByPlace(resolvedPlace.id, Math.max(limit * 12, 320));
+        const mbSeed: StudioSeedTrack[] = [];
+        for (let index = 0; index < mbTracks.length; index += 1) {
+          const row = mbTracks[index];
+          const artist = canonicalizeDisplayName(row.artist || '');
+          const title = (row.title || '').trim();
+          if (!artist || !title) continue;
+          if (isVariantStudioTitle(title)) continue;
+          if (!isLikelySongRecording(artist, title)) continue;
 
-  if (!discogsLabelId || !Number.isFinite(discogsLabelId) || discogsLabelId <= 0) {
-    const searchCandidates = Array.from(
-      new Set(
-        [
-          studioName,
-          ...(resolved?.acceptedStudioNames || []),
-          studioName.replace(/,\s*stockholm$/i, ''),
-          studioName.replace(/,\s*london$/i, ''),
-          studioName.replace(/,\s*los angeles$/i, ''),
-        ]
-          .map((value) => canonicalizeDisplayName(value || ''))
-          .filter((value) => value.length > 0)
-      )
-    );
+          const year = extractYear(row.begin) ?? extractYear(row.end);
+          if (year !== null) {
+            if (typeof activeStartYear === 'number' && year < activeStartYear) continue;
+            if (typeof activeEndYear === 'number' && year > activeEndYear) continue;
+          }
 
-    for (const searchCandidate of searchCandidates) {
-      try {
-        discogsLabelId = await searchDiscogsStudioLabelId(searchCandidate) || undefined;
-      } catch {
-        discogsLabelId = undefined;
+          mbSeed.push({
+            artist,
+            title,
+            studioName,
+            releaseId: 10_000_000 + index,
+            releaseTitle: 'MusicBrainz recorded-at relation',
+            sourceRef: `musicbrainz:place:${resolvedPlace.id}:recording:${row.recordingMbid}`,
+            source: 'musicbrainz',
+            recordedYear: year ?? undefined,
+          });
+        }
+
+        const dedupe = new Set<string>();
+        const uniqueMbSeed: StudioSeedTrack[] = [];
+        for (const row of mbSeed) {
+          const key = normalizeTrackKey(row.artist, row.title);
+          if (!key || dedupe.has(key)) continue;
+          dedupe.add(key);
+          uniqueMbSeed.push(row);
+        }
+
+        studioTracks = diversifyStudioSeedTracks(uniqueMbSeed, Math.max(limit * 3, 120));
       }
-      if (discogsLabelId && Number.isFinite(discogsLabelId) && discogsLabelId > 0) {
-        discogsLabelSource = 'search';
-        break;
+    } catch {
+      // MusicBrainz studio backfill is best-effort.
+    }
+  }
+
+  const minimumBreadthTarget = Math.min(8, Math.max(4, Math.floor(limit / 3)));
+  const shouldUseDiscogsFallback = studioTracks.length < Math.min(40, limit) || countUniqueArtists(studioTracks) < minimumBreadthTarget;
+
+  if (discogsEnabled && shouldUseDiscogsFallback) {
+    attemptedDiscogs = true;
+
+    if (!discogsLabelId || !Number.isFinite(discogsLabelId) || discogsLabelId <= 0) {
+      const searchCandidates = Array.from(
+        new Set(
+          [
+            studioName,
+            ...acceptedStudioNames,
+            studioName.replace(/,\s*stockholm$/i, ''),
+            studioName.replace(/,\s*london$/i, ''),
+            studioName.replace(/,\s*los angeles$/i, ''),
+          ]
+            .map((value) => canonicalizeDisplayName(value || ''))
+            .filter((value) => value.length > 0)
+        )
+      );
+
+      for (const searchCandidate of searchCandidates) {
+        try {
+          discogsLabelId = await searchDiscogsStudioLabelId(searchCandidate) || undefined;
+        } catch {
+          discogsLabelId = undefined;
+        }
+        if (discogsLabelId && Number.isFinite(discogsLabelId) && discogsLabelId > 0) {
+          discogsLabelSource = 'search';
+          break;
+        }
       }
     }
-  }
 
-  if (!discogsLabelId || !Number.isFinite(discogsLabelId) || discogsLabelId <= 0) {
-    return {
-      attempted: false,
-      studioName,
-      studioIdentityKey,
-      discogsLabelId,
-      discogsLabelSource,
-      imported: 0,
-      insertedRecordings: 0,
-      insertedEvidence: 0,
-      skippedExistingEvidence: 0,
-      skippedInvalid: 0,
-      skippedReason: 'studio_discogs_label_missing',
-    };
-  }
+    if (discogsLabelId && Number.isFinite(discogsLabelId) && discogsLabelId > 0) {
+      let discogsTracks = await fetchDiscogsStudioTracksByLabel(discogsLabelId, studioName, Math.max(limit, 120), activeStartYear, activeEndYear);
+      if (artistHints.length > 0) {
+        const fallbackLimit = Math.max(50, Math.min(limit, 120));
+        const fallbackTracks = await fetchDiscogsStudioTracksByArtistHints(studioName, artistHints, fallbackLimit, activeStartYear, activeEndYear);
+        const dedupeKeys = new Set<string>();
+        const merged: typeof discogsTracks = [];
+        for (const row of [...fallbackTracks, ...discogsTracks]) {
+          const key = `${row.artist.toLowerCase()}::${row.title.toLowerCase()}::${row.releaseId}`;
+          if (dedupeKeys.has(key)) continue;
+          dedupeKeys.add(key);
+          merged.push(row);
+          if (merged.length >= Math.max(limit, 120)) break;
+        }
+        discogsTracks = merged;
+      }
+      if ((discogsTracks.length < Math.min(30, limit) || countUniqueArtists(discogsTracks) < minimumBreadthTarget) && artistHints.length > 0) {
+        const catalogTracks = await fetchDiscogsStudioTracksByArtistCatalog(studioName, artistHints, Math.max(50, Math.min(limit, 120)), activeStartYear, activeEndYear);
+        const dedupeKeys = new Set<string>();
+        const merged: typeof discogsTracks = [];
+        for (const row of [...catalogTracks, ...discogsTracks]) {
+          const key = `${row.artist.toLowerCase()}::${row.title.toLowerCase()}::${row.releaseId}`;
+          if (dedupeKeys.has(key)) continue;
+          dedupeKeys.add(key);
+          merged.push(row);
+          if (merged.length >= Math.max(limit, 120)) break;
+        }
+        discogsTracks = merged;
+      }
 
-  const sourcePlaylistId = ensureSourcePlaylistId(studioName);
-  const activeStartYear = typeof params.activeStartYear === 'number' ? params.activeStartYear : undefined;
-  const activeEndYear = typeof params.activeEndYear === 'number' ? params.activeEndYear : undefined;
-  let discogsTracks = await fetchDiscogsStudioTracksByLabel(discogsLabelId, studioName, limit, activeStartYear, activeEndYear);
-  const artistHints = Array.isArray(params.artistHints)
-    ? Array.from(new Set(params.artistHints.map((value) => canonicalizeDisplayName(value || '')).filter((value) => value.length > 0))).slice(0, 12)
-    : [];
-  if (artistHints.length > 0) {
-    const fallbackLimit = Math.max(30, Math.min(limit, 100));
-    const fallbackTracks = await fetchDiscogsStudioTracksByArtistHints(studioName, artistHints, fallbackLimit, activeStartYear, activeEndYear);
-    const dedupeKeys = new Set<string>();
-    const merged: typeof discogsTracks = [];
-    for (const row of [...fallbackTracks, ...discogsTracks]) {
-      const key = `${row.artist.toLowerCase()}::${row.title.toLowerCase()}::${row.releaseId}`;
-      if (dedupeKeys.has(key)) continue;
-      dedupeKeys.add(key);
-      merged.push(row);
-      if (merged.length >= limit) break;
+      const discogsSeed: StudioSeedTrack[] = discogsTracks.map((row) => ({
+        artist: canonicalizeDisplayName(row.artist),
+        title: row.title.trim(),
+        studioName,
+        releaseId: row.releaseId,
+        releaseTitle: row.releaseTitle,
+        sourceRef: row.sourceRef,
+        source: 'discogs',
+      }));
+
+      const mergedByKey = new Map<string, StudioSeedTrack>();
+      for (const row of [...studioTracks, ...discogsSeed]) {
+        const key = normalizeTrackKey(row.artist, row.title);
+        if (!key || mergedByKey.has(key)) continue;
+        mergedByKey.set(key, row);
+      }
+      studioTracks = Array.from(mergedByKey.values());
     }
-    discogsTracks = merged;
-  }
-  if (discogsTracks.length < Math.min(30, limit) && artistHints.length > 0) {
-    const catalogTracks = await fetchDiscogsStudioTracksByArtistCatalog(studioName, artistHints, Math.max(30, Math.min(limit, 100)), activeStartYear, activeEndYear);
-    const dedupeKeys = new Set<string>();
-    const merged: typeof discogsTracks = [];
-    for (const row of [...catalogTracks, ...discogsTracks]) {
-      const key = `${row.artist.toLowerCase()}::${row.title.toLowerCase()}::${row.releaseId}`;
-      if (dedupeKeys.has(key)) continue;
-      dedupeKeys.add(key);
-      merged.push(row);
-      if (merged.length >= limit) break;
-    }
-    discogsTracks = merged;
   }
 
   const curatedRecordedTracks = Array.isArray(params.curatedRecordedTracks)
@@ -187,7 +341,7 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
       : [];
   if (curatedRecordedTracks.length > 0) {
     const dedupeKeys = new Set<string>();
-    const merged: typeof discogsTracks = [];
+    const merged: StudioSeedTrack[] = [];
     let syntheticReleaseId = 1;
     for (const curated of curatedRecordedTracks) {
       const artist = canonicalizeDisplayName(curated.artist || '');
@@ -203,23 +357,33 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
         releaseId: syntheticReleaseId,
         releaseTitle: 'Curated studio recording seed',
         sourceRef: `curated:studio:${studioIdentityKey || buildStudioCanonicalKey(studioName)}:${syntheticReleaseId}`,
+        source: 'discogs',
       });
       syntheticReleaseId += 1;
     }
-    for (const row of discogsTracks) {
+    for (const row of studioTracks) {
       const key = `${row.artist.toLowerCase()}::${row.title.toLowerCase()}`;
       if (dedupeKeys.has(key)) continue;
       dedupeKeys.add(key);
       merged.push(row);
-      if (merged.length >= limit) break;
+      if (merged.length >= Math.max(limit, 120)) break;
     }
-    discogsTracks = merged.slice(0, limit);
+    studioTracks = merged;
   }
-  if (discogsTracks.length === 0) {
+
+  studioTracks = diversifyStudioSeedTracks(studioTracks, Math.max(limit, 120));
+
+  if (studioTracks.length === 0) {
+    const skippedReason = !attemptedMusicBrainz && !attemptedDiscogs
+      ? (!musicBrainzEnabled && !discogsEnabled ? 'all_sources_disabled' : !discogsEnabled ? 'missing_discogs_token' : 'musicbrainz_not_attempted')
+      : 'no_rows';
     return {
-      attempted: true,
+      attempted: attemptedMusicBrainz || attemptedDiscogs,
+      source: attemptedMusicBrainz && attemptedDiscogs ? 'hybrid' : attemptedMusicBrainz ? 'musicbrainz' : 'discogs',
       studioName,
       studioIdentityKey,
+      musicBrainzPlaceId,
+      musicBrainzPlaceName,
       discogsLabelId,
       discogsLabelSource,
       imported: 0,
@@ -227,7 +391,7 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
       insertedEvidence: 0,
       skippedExistingEvidence: 0,
       skippedInvalid: 0,
-      skippedReason: 'no_rows',
+      skippedReason,
     };
   }
 
@@ -261,13 +425,20 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
   `);
 
   const studioCanonical = buildStudioCanonicalKey(studioName);
-  deletePriorStudioEvidenceForSource.run(sourcePlaylistId, studioCanonical);
+  const sourcesUsed = new Set<'discogs' | 'musicbrainz'>(studioTracks.map((row) => row.source));
+  const sourcePlaylistBySource = new Map<'discogs' | 'musicbrainz', number>();
+  for (const source of sourcesUsed) {
+    const sourcePlaylistId = ensureSourcePlaylistId(studioName, source);
+    sourcePlaylistBySource.set(source, sourcePlaylistId);
+    deletePriorStudioEvidenceForSource.run(sourcePlaylistId, studioCanonical);
+  }
+
   let insertedRecordings = 0;
   let insertedEvidence = 0;
   let skippedExistingEvidence = 0;
   let skippedInvalid = 0;
 
-  for (const track of discogsTracks) {
+  for (const track of studioTracks) {
     const artist = canonicalizeDisplayName(track.artist);
     const title = track.title.trim();
     if (!artist || !title) {
@@ -288,6 +459,12 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
       insertedRecordings += 1;
     }
 
+    const sourcePlaylistId = sourcePlaylistBySource.get(track.source);
+    if (typeof sourcePlaylistId !== 'number' || !Number.isFinite(sourcePlaylistId)) {
+      skippedInvalid += 1;
+      continue;
+    }
+
     const exists = studioEvidenceExists.get(recordingRow.id, sourcePlaylistId, studioCanonical) as { 1: number } | undefined;
     if (exists) {
       skippedExistingEvidence += 1;
@@ -299,16 +476,19 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
   }
 
   return {
-    attempted: true,
+    attempted: attemptedMusicBrainz || attemptedDiscogs,
+    source: attemptedMusicBrainz && attemptedDiscogs ? 'hybrid' : attemptedMusicBrainz ? 'musicbrainz' : 'discogs',
     studioName,
     studioIdentityKey,
+    musicBrainzPlaceId,
+    musicBrainzPlaceName,
     discogsLabelId,
     discogsLabelSource,
-    imported: discogsTracks.length,
+    imported: studioTracks.length,
     insertedRecordings,
     insertedEvidence,
     skippedExistingEvidence,
     skippedInvalid,
-    skippedReason: discogsTracks.length > 0 ? undefined : 'no_rows',
+    skippedReason: studioTracks.length > 0 ? undefined : 'no_rows',
   };
 }

--- a/server/src/services/evidence-backfill-studio.ts
+++ b/server/src/services/evidence-backfill-studio.ts
@@ -65,6 +65,31 @@ function normalizeTrackKey(artist: string, title: string): string {
   return `${artist.trim().toLowerCase()}::${title.trim().toLowerCase()}`;
 }
 
+function normalizeArtistKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function buildPreferredArtistKeys(values: string[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeArtistKey(value || ''))
+        .filter((value) => value.length >= 3)
+    )
+  );
+}
+
+function artistMatchesPreferred(artist: string, preferredArtistKeys: string[]): boolean {
+  if (preferredArtistKeys.length === 0) return false;
+  const normalizedArtist = normalizeArtistKey(artist);
+  if (!normalizedArtist) return false;
+  return preferredArtistKeys.some((preferred) => normalizedArtist === preferred || normalizedArtist.includes(preferred));
+}
+
 function extractYear(value: string | null | undefined): number | null {
   if (!value) return null;
   const match = value.match(/\b(19\d{2}|20\d{2})\b/);
@@ -97,6 +122,85 @@ function isLikelySongRecording(artist: string, title: string): boolean {
 
 function countUniqueArtists(rows: Array<{ artist: string }>): number {
   return new Set(rows.map((row) => row.artist.trim().toLowerCase()).filter(Boolean)).size;
+}
+
+function countPreferredArtistMatches(
+  rows: Array<{ artist: string }>,
+  preferredArtistKeys: string[]
+): number {
+  if (preferredArtistKeys.length === 0) return 0;
+  return rows.reduce((count, row) => count + (artistMatchesPreferred(row.artist, preferredArtistKeys) ? 1 : 0), 0);
+}
+
+function countUniquePreferredArtists(
+  rows: Array<{ artist: string }>,
+  preferredArtistKeys: string[]
+): number {
+  if (preferredArtistKeys.length === 0) return 0;
+  const matched = new Set<string>();
+  for (const row of rows) {
+    const normalizedArtist = normalizeArtistKey(row.artist);
+    if (!normalizedArtist) continue;
+    for (const preferred of preferredArtistKeys) {
+      if (normalizedArtist === preferred || normalizedArtist.includes(preferred)) {
+        matched.add(preferred);
+      }
+    }
+  }
+  return matched.size;
+}
+
+function isMainstreamStudioPrompt(prompt: string | undefined): boolean {
+  const value = (prompt || '').toLowerCase();
+  if (!value) return false;
+  return /\bbest known\b|\bwell known\b|\biconic\b|\bclassic\b|\bessential\b|\bhits?\b|\bpopular\b|\bfamous\b|\bmegaklassiker\b/.test(value);
+}
+
+function getStudioSeedQualityScore(
+  track: StudioSeedTrack,
+  preferredArtistKeys: string[],
+  mainstreamPrompt: boolean
+): number {
+  const artist = track.artist;
+  const title = track.title;
+  let score = 0;
+
+  if (artistMatchesPreferred(artist, preferredArtistKeys)) score += 12;
+  if (track.source === 'discogs') score += mainstreamPrompt ? 5 : 2;
+  if (isLikelySongRecording(artist, title)) score += 3;
+  if (isVariantStudioTitle(title)) score -= 10;
+
+  const artistCommaCount = (artist.match(/,/g) || []).length;
+  if (artistCommaCount >= 2) score -= 8;
+  if (title.includes(':')) score -= 6;
+  if (artist.length >= 60) score -= 4;
+  if (title.length >= 70) score -= 4;
+
+  const artistLower = artist.toLowerCase();
+  const titleLower = title.toLowerCase();
+  if (/\b(orchestra|symphony|philharmonic|choir|ensemble|quartet|quintet|conductor)\b/.test(artistLower)) score -= 10;
+  if (/\b(op\.|opus|concerto|sonata|suite|movement|act\s+\d+|scene\s+\d+|recitativo|aria|overture)\b/.test(titleLower)) score -= 10;
+
+  return score;
+}
+
+function prioritizeStudioSeedTracks(
+  tracks: StudioSeedTrack[],
+  preferredArtistKeys: string[],
+  mainstreamPrompt: boolean
+): StudioSeedTrack[] {
+  const scored = tracks.map((track, index) => ({
+    track,
+    index,
+    score: getStudioSeedQualityScore(track, preferredArtistKeys, mainstreamPrompt),
+  }));
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.index - b.index;
+  });
+
+  return scored.map((row) => row.track);
 }
 
 function diversifyStudioSeedTracks<T extends { artist: string; title: string }>(tracks: T[], desired: number): T[] {
@@ -177,6 +281,17 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
   const artistHints = Array.isArray(params.artistHints)
     ? Array.from(new Set(params.artistHints.map((value) => canonicalizeDisplayName(value || '')).filter((value) => value.length > 0))).slice(0, 12)
     : [];
+  const identityPreferredArtists = Array.isArray(resolved?.preferredArtists)
+    ? resolved.preferredArtists.map((value) => canonicalizeDisplayName(value || '')).filter((value) => value.length > 0)
+    : [];
+  const mainstreamPrompt = isMainstreamStudioPrompt(params.prompt);
+  const effectiveArtistHints = Array.from(
+    new Set([
+      ...artistHints,
+      ...(mainstreamPrompt ? identityPreferredArtists : identityPreferredArtists.slice(0, 5)),
+    ])
+  ).slice(0, 16);
+  const preferredArtistKeys = buildPreferredArtistKeys(Array.isArray(resolved?.preferredArtists) ? resolved.preferredArtists : []);
 
   let attemptedMusicBrainz = false;
   let attemptedDiscogs = false;
@@ -251,7 +366,17 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
   }
 
   const minimumBreadthTarget = Math.min(8, Math.max(4, Math.floor(limit / 3)));
-  const shouldUseDiscogsFallback = studioTracks.length < Math.min(40, limit) || countUniqueArtists(studioTracks) < minimumBreadthTarget;
+  const preferredMatchTarget = Math.min(8, Math.max(3, Math.floor(limit / 2)));
+  const preferredMatchCount = countPreferredArtistMatches(studioTracks, preferredArtistKeys);
+  const uniquePreferredArtists = countUniquePreferredArtists(studioTracks, preferredArtistKeys);
+  const preferredArtistVarietyTarget = Math.min(4, preferredArtistKeys.length);
+  const shouldUseDiscogsFallback =
+    studioTracks.length < Math.min(40, limit)
+    || countUniqueArtists(studioTracks) < minimumBreadthTarget
+    || (mainstreamPrompt && preferredArtistKeys.length > 0 && (
+      preferredMatchCount < preferredMatchTarget
+      || uniquePreferredArtists < preferredArtistVarietyTarget
+    ));
 
   if (discogsEnabled && shouldUseDiscogsFallback) {
     attemptedDiscogs = true;
@@ -286,9 +411,9 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
 
     if (discogsLabelId && Number.isFinite(discogsLabelId) && discogsLabelId > 0) {
       let discogsTracks = await fetchDiscogsStudioTracksByLabel(discogsLabelId, studioName, Math.max(limit, 120), activeStartYear, activeEndYear);
-      if (artistHints.length > 0) {
+      if (effectiveArtistHints.length > 0) {
         const fallbackLimit = Math.max(50, Math.min(limit, 120));
-        const fallbackTracks = await fetchDiscogsStudioTracksByArtistHints(studioName, artistHints, fallbackLimit, activeStartYear, activeEndYear);
+        const fallbackTracks = await fetchDiscogsStudioTracksByArtistHints(studioName, effectiveArtistHints, fallbackLimit, activeStartYear, activeEndYear);
         const dedupeKeys = new Set<string>();
         const merged: typeof discogsTracks = [];
         for (const row of [...fallbackTracks, ...discogsTracks]) {
@@ -300,8 +425,8 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
         }
         discogsTracks = merged;
       }
-      if ((discogsTracks.length < Math.min(30, limit) || countUniqueArtists(discogsTracks) < minimumBreadthTarget) && artistHints.length > 0) {
-        const catalogTracks = await fetchDiscogsStudioTracksByArtistCatalog(studioName, artistHints, Math.max(50, Math.min(limit, 120)), activeStartYear, activeEndYear);
+      if ((discogsTracks.length < Math.min(30, limit) || countUniqueArtists(discogsTracks) < minimumBreadthTarget) && effectiveArtistHints.length > 0) {
+        const catalogTracks = await fetchDiscogsStudioTracksByArtistCatalog(studioName, effectiveArtistHints, Math.max(50, Math.min(limit, 120)), activeStartYear, activeEndYear);
         const dedupeKeys = new Set<string>();
         const merged: typeof discogsTracks = [];
         for (const row of [...catalogTracks, ...discogsTracks]) {
@@ -325,7 +450,8 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
       }));
 
       const mergedByKey = new Map<string, StudioSeedTrack>();
-      for (const row of [...studioTracks, ...discogsSeed]) {
+      const sourcePriority = mainstreamPrompt ? [...discogsSeed, ...studioTracks] : [...studioTracks, ...discogsSeed];
+      for (const row of sourcePriority) {
         const key = normalizeTrackKey(row.artist, row.title);
         if (!key || mergedByKey.has(key)) continue;
         mergedByKey.set(key, row);
@@ -333,6 +459,8 @@ export async function backfillStudioFromDiscogs(params: StudioEvidenceBackfillPa
       studioTracks = Array.from(mergedByKey.values());
     }
   }
+
+  studioTracks = prioritizeStudioSeedTracks(studioTracks, preferredArtistKeys, mainstreamPrompt);
 
   const curatedRecordedTracks = Array.isArray(params.curatedRecordedTracks)
     ? params.curatedRecordedTracks

--- a/server/src/services/gemini.ts
+++ b/server/src/services/gemini.ts
@@ -84,12 +84,14 @@ interface TruthDetails {
   };
   studio_sync?: {
     studio: string;
-    source: 'discogs';
+    source: 'discogs' | 'musicbrainz' | 'hybrid';
     attempted: boolean;
     imported: number;
     inserted_evidence: number;
     discogs_label_id?: number;
     discogs_label_source?: 'identity' | 'search';
+    musicbrainz_place_id?: string;
+    musicbrainz_place_name?: string;
     skipped_reason?: string;
   };
   studio_constraint?: {
@@ -1679,36 +1681,41 @@ function getStudioTrackVariantPenalty(songTitle: string): number {
   return penalty;
 }
 
+function getStudioTrackCommercialPenalty(artistName: string, songTitle: string): number {
+  const artist = artistName.toLowerCase();
+  const title = songTitle.toLowerCase();
+  let penalty = 0;
+
+  const artistCommaCount = (artistName.match(/,/g) || []).length;
+  if (artistCommaCount >= 2) penalty += 6;
+  if (artistName.length >= 64) penalty += 6;
+  if (songTitle.length >= 80) penalty += 6;
+
+  if (/\b(orchestra|symphony|philharmonic|choir|ensemble|quartet|quintet|conductor)\b/.test(artist)) penalty += 8;
+  if (/\b(op\.|opus|concerto|sonata|suite|movement|act\s+\d+|scene\s+\d+)\b/.test(title)) penalty += 8;
+  if (/\b(arie|aria|overture|recitativo|sinfonia)\b/.test(title)) penalty += 6;
+
+  return penalty;
+}
+
 async function rankStudioTracksByRecognition(
-  prompt: string,
+  _prompt: string,
   tracks: Track[],
   preferredArtists: Set<string>
 ): Promise<Track[]> {
   if (tracks.length <= 1) return tracks;
 
-  const scored = await Promise.all(
-    tracks.map(async (track, index) => {
-      let recognitionScore = 0;
-      try {
-        const info = await searchTrackWithDiagnostics(track.artist, track.song, prompt);
-        if (!track.spotify_url && info.spotify_url) track.spotify_url = info.spotify_url;
-        if (!track.album_image_url && info.album_image_url) track.album_image_url = info.album_image_url;
-        if (typeof track.release_year !== 'number' && typeof info.release_year === 'number') {
-          track.release_year = info.release_year;
-        }
-        recognitionScore = typeof info.score === 'number' && Number.isFinite(info.score)
-          ? info.score
-          : 0;
-      } catch {
-        recognitionScore = 0;
-      }
-
-      const variantPenalty = getStudioTrackVariantPenalty(track.song);
-      const preferredArtistBoost = preferredArtists.has(normalize(track.artist)) ? 3 : 0;
-      const finalScore = recognitionScore - variantPenalty + preferredArtistBoost;
-      return { track, index, finalScore };
-    })
-  );
+  const scored = tracks.map((track, index) => {
+    const variantPenalty = getStudioTrackVariantPenalty(track.song);
+    const commercialPenalty = getStudioTrackCommercialPenalty(track.artist, track.song);
+    const preferredArtistBoost = preferredArtists.has(normalize(track.artist)) ? 3 : 0;
+    const releaseYear = typeof track.release_year === 'number' && Number.isFinite(track.release_year)
+      ? Math.floor(track.release_year)
+      : null;
+    const yearBoost = releaseYear !== null && releaseYear >= 1955 && releaseYear <= 1999 ? 1 : 0;
+    const finalScore = preferredArtistBoost + yearBoost - variantPenalty - commercialPenalty;
+    return { track, index, finalScore };
+  });
 
   scored.sort((a, b) => {
     if (b.finalScore !== a.finalScore) return b.finalScore - a.finalScore;
@@ -3123,6 +3130,50 @@ function applyGeneralArtistDiversity(tracks: Track[]): Track[] {
   return chosen.length > 0 ? chosen : tracks;
 }
 
+function applyStudioArtistDiversity(tracks: Track[]): Track[] {
+  if (tracks.length <= 1) return tracks;
+
+  const desiredCount = Math.min(MAX_PLAYLIST_TRACKS, tracks.length);
+  const chosen: Track[] = [];
+  const chosenKeys = new Set<string>();
+  const artistCounts = new Map<string, number>();
+
+  const getTrackKey = (track: Track): string => `${normalize(track.artist)}::${normalize(track.song)}`;
+
+  const addWithArtistCap = (artistCap: number): void => {
+    for (const track of tracks) {
+      if (chosen.length >= desiredCount) break;
+      const trackKey = getTrackKey(track);
+      if (!trackKey || chosenKeys.has(trackKey)) continue;
+      const artistKey = normalize(track.artist);
+      if (!artistKey) continue;
+      const artistCount = artistCounts.get(artistKey) || 0;
+      if (artistCount >= artistCap) continue;
+
+      chosen.push(track);
+      chosenKeys.add(trackKey);
+      artistCounts.set(artistKey, artistCount + 1);
+    }
+  };
+
+  addWithArtistCap(1);
+  if (chosen.length < desiredCount) addWithArtistCap(2);
+  if (chosen.length < desiredCount) addWithArtistCap(3);
+  if (chosen.length < desiredCount) addWithArtistCap(5);
+
+  if (chosen.length < desiredCount) {
+    for (const track of tracks) {
+      if (chosen.length >= desiredCount) break;
+      const trackKey = getTrackKey(track);
+      if (!trackKey || chosenKeys.has(trackKey)) continue;
+      chosen.push(track);
+      chosenKeys.add(trackKey);
+    }
+  }
+
+  return chosen.length > 0 ? chosen : tracks;
+}
+
 function staggerArtistsForFlow(tracks: Track[]): Track[] {
   if (tracks.length < 3) return tracks;
 
@@ -4118,7 +4169,7 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
         if (!studioBackfillWindow.allowed) {
           truth.studio_sync = {
             studio: studioName,
-            source: 'discogs',
+            source: 'hybrid',
             attempted: false,
             imported: 0,
             inserted_evidence: 0,
@@ -4143,12 +4194,14 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
             );
             truth.studio_sync = {
               studio: studioBackfillResult.studioName,
-              source: 'discogs',
+              source: studioBackfillResult.source,
               attempted: studioBackfillResult.attempted,
               imported: studioBackfillResult.imported,
               inserted_evidence: studioBackfillResult.insertedEvidence,
               discogs_label_id: studioBackfillResult.discogsLabelId,
               discogs_label_source: studioBackfillResult.discogsLabelSource,
+              musicbrainz_place_id: studioBackfillResult.musicBrainzPlaceId,
+              musicbrainz_place_name: studioBackfillResult.musicBrainzPlaceName,
               skipped_reason: studioBackfillResult.skippedReason,
             };
 
@@ -4165,7 +4218,7 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
               : `error:${message.slice(0, 120)}`;
             truth.studio_sync = {
               studio: studioName,
-              source: 'discogs',
+              source: 'hybrid',
               attempted: false,
               imported: 0,
               inserted_evidence: 0,
@@ -4179,7 +4232,7 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
       } else {
         truth.studio_sync = {
           studio: studioName,
-          source: 'discogs',
+          source: 'hybrid',
           attempted: false,
           imported: 0,
           inserted_evidence: 0,
@@ -4530,9 +4583,10 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
   if (constraint?.kind === 'studio') {
     const preferredStudioArtists = new Set((constraint.studioPreferredArtists || []).map((value) => normalize(value)).filter(Boolean));
     playlist.tracks = await applyRequestedDecadeFilter(translatedPrompt, playlist.tracks);
-    playlist.tracks = await rankStudioTracksByRecognition(translatedPrompt, playlist.tracks, preferredStudioArtists);
     playlist.tracks = applyStudioIdentityYearBounds(constraint, playlist.tracks);
     playlist.tracks = applyStudioCuratedTrackWhitelist(constraint, playlist.tracks);
+    playlist.tracks = applyStudioArtistDiversity(playlist.tracks);
+    playlist.tracks = await rankStudioTracksByRecognition(translatedPrompt, playlist.tracks, preferredStudioArtists);
   }
   const studioVerifiedAfterDecadeFilter = constraint?.kind === 'studio' ? playlist.tracks.length : null;
 
@@ -4616,40 +4670,66 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
   }
 
   // Store with translated prompt
-  const rawTags = await generateTags(translatedPrompt);
-  const tags = canonicalizeGeneratedTags(rawTags);
-  const locations = await generateLocationMetadata(translatedPrompt);
-  const promptStudios: string[] = [];
-  const promptVenues: string[] = [];
-  const extractedPlace = extractPlaceEntityFromPrompt(translatedPrompt);
-  if (extractedPlace && isValidPlaceEntityName(extractedPlace)) {
-    const heuristicType = inferPlaceTypeHeuristic(extractedPlace);
-    const placeType = heuristicType === 'unknown'
-      ? await classifyPlaceEntity(extractedPlace)
-      : heuristicType;
-    if (placeType === 'studio') {
-      promptStudios.push(extractedPlace);
-    } else if (placeType === 'venue') {
-      promptVenues.push(extractedPlace);
+  let tags: string[] = [];
+  let mergedLocations: { countries: string[]; cities: string[]; studios: string[]; venues: string[] } = {
+    countries: [],
+    cities: [],
+    studios: [],
+    venues: [],
+  };
+  let scenes: string[] = [];
+  let influences: InfluenceEdge[] = [];
+  let generatedCredits: CreditEntity[] = [];
+  let equipment: EquipmentEntity[] = [];
+  let memberships: MembershipEntity[] = [];
+
+  if (constraint?.kind === 'studio') {
+    tags = canonicalizeGeneratedTags(['studio-evidence', 'recorded-at', 'studio']);
+    const studioNames = Array.isArray(constraint.studioAcceptedNames) && constraint.studioAcceptedNames.length > 0
+      ? dedupeStudiosByCanonical(constraint.studioAcceptedNames)
+      : [constraint.value].filter(Boolean);
+    mergedLocations = {
+      countries: [],
+      cities: [],
+      studios: studioNames.slice(0, 3),
+      venues: [],
+    };
+  } else {
+    const rawTags = await generateTags(translatedPrompt);
+    tags = canonicalizeGeneratedTags(rawTags);
+    const locations = await generateLocationMetadata(translatedPrompt);
+    const promptStudios: string[] = [];
+    const promptVenues: string[] = [];
+    const extractedPlace = extractPlaceEntityFromPrompt(translatedPrompt);
+    if (extractedPlace && isValidPlaceEntityName(extractedPlace)) {
+      const heuristicType = inferPlaceTypeHeuristic(extractedPlace);
+      const placeType = heuristicType === 'unknown'
+        ? await classifyPlaceEntity(extractedPlace)
+        : heuristicType;
+      if (placeType === 'studio') {
+        promptStudios.push(extractedPlace);
+      } else if (placeType === 'venue') {
+        promptVenues.push(extractedPlace);
+      }
     }
+    const mergedStudios = hasStudioIntent(translatedPrompt)
+      ? dedupeStudiosByCanonical([...locations.studios, ...promptStudios]).slice(0, 3)
+      : [];
+    const mergedVenues = Array.from(new Set([...locations.venues, ...promptVenues])).slice(0, 3);
+    mergedLocations = { ...locations, studios: mergedStudios, venues: mergedVenues };
+    const generatedScenes = await generateScenes(translatedPrompt);
+    scenes = constraint?.kind === 'credit'
+      ? []
+      : await bootstrapScenesFromTracks(translatedPrompt, playlist.tracks, generatedScenes);
+    influences = constraint?.kind === 'credit'
+      ? []
+      : await generateInfluences(translatedPrompt, playlist.tracks);
+    generatedCredits = constraint?.kind === 'credit'
+      ? []
+      : await generateCredits(translatedPrompt, playlist.tracks);
+    equipment = await generateEquipment(translatedPrompt, playlist.tracks);
+    memberships = await generateArtistMemberships(translatedPrompt, playlist.tracks);
   }
-  const mergedStudios = hasStudioIntent(translatedPrompt)
-    ? dedupeStudiosByCanonical([...locations.studios, ...promptStudios]).slice(0, 3)
-    : [];
-  const mergedVenues = Array.from(new Set([...locations.venues, ...promptVenues])).slice(0, 3);
-  const mergedLocations = { ...locations, studios: mergedStudios, venues: mergedVenues };
-  const generatedScenes = await generateScenes(translatedPrompt);
-  const scenes = constraint?.kind === 'credit'
-    ? []
-    : await bootstrapScenesFromTracks(translatedPrompt, playlist.tracks, generatedScenes);
-  const influences = constraint?.kind === 'credit'
-    ? []
-    : await generateInfluences(translatedPrompt, playlist.tracks);
-  const generatedCredits = constraint?.kind === 'credit'
-    ? []
-    : await generateCredits(translatedPrompt, playlist.tracks);
-  const equipment = await generateEquipment(translatedPrompt, playlist.tracks);
-  const memberships = await generateArtistMemberships(translatedPrompt, playlist.tracks);
   const truthRoutePersistedCredits = constraint?.kind === 'credit'
     && typeof constraint.value === 'string'
     && constraint.value.trim().length > 0
@@ -4670,10 +4750,10 @@ export async function generatePlaylist(userPrompt: string): Promise<PlaylistResp
     ? truthRoutePersistedCredits
     : mixedPromptPersistedCredits;
   console.log('[Gemini] Generated tags:', tags);
-  console.log('[Gemini] Generated countries:', locations.countries);
-  console.log('[Gemini] Generated cities:', locations.cities);
+  console.log('[Gemini] Generated countries:', mergedLocations.countries);
+  console.log('[Gemini] Generated cities:', mergedLocations.cities);
   console.log('[Gemini] Generated studios:', mergedLocations.studios);
-  console.log('[Gemini] Generated venues:', locations.venues);
+  console.log('[Gemini] Generated venues:', mergedLocations.venues);
   console.log('[Gemini] Generated scenes:', scenes);
   console.log('[Gemini] Generated influences:', influences);
   console.log('[Gemini] Generated credits:', generatedCredits);

--- a/server/src/services/musicbrainz.ts
+++ b/server/src/services/musicbrainz.ts
@@ -5,6 +5,23 @@ export interface MusicBrainzArtistSearchResult {
   type: string;
 }
 
+export interface MusicBrainzPlaceSearchResult {
+  id: string;
+  name: string;
+  score: number;
+  type: string;
+  disambiguation: string;
+}
+
+export interface MusicBrainzStudioTrack {
+  artist: string;
+  title: string;
+  recordingMbid: string;
+  relationType: string;
+  begin: string | null;
+  end: string | null;
+}
+
 interface MusicBrainzCreditTrack {
   artist: string;
   title: string;
@@ -88,6 +105,20 @@ function formatArtistCredit(artistCredit: unknown): string {
   }
 
   return combined.trim();
+}
+
+function normalizeStudioType(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeStudioMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\brecording\s+studios?\b/g, 'studio')
+    .replace(/\bstudios\b/g, 'studio')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function mapCreditRoleToRelationTypes(role: string): Set<string> {
@@ -214,6 +245,153 @@ export async function searchMusicBrainzArtistsByName(name: string, limit = 5): P
       return { id, name: artistName, score, type };
     })
     .filter((item): item is MusicBrainzArtistSearchResult => Boolean(item));
+}
+
+export async function searchMusicBrainzPlacesByName(name: string, limit = 5): Promise<MusicBrainzPlaceSearchResult[]> {
+  const trimmed = name.trim();
+  if (!trimmed) return [];
+
+  const safeLimit = Math.max(1, Math.min(20, Math.floor(limit)));
+  const query = encodeURIComponent(trimmed);
+  const url = `${MUSICBRAINZ_BASE_URL}/place/?query=${query}&fmt=json&limit=${safeLimit}`;
+  const raw = await rateLimitedFetchJson(url) as { places?: unknown[] };
+  const places = Array.isArray(raw.places) ? raw.places : [];
+
+  return places
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const row = item as {
+        id?: unknown;
+        name?: unknown;
+        score?: unknown;
+        type?: unknown;
+        disambiguation?: unknown;
+      };
+      const id = typeof row.id === 'string' ? row.id.trim() : '';
+      const placeName = typeof row.name === 'string' ? row.name.trim() : '';
+      const score = Number(row.score || 0);
+      const type = typeof row.type === 'string' ? row.type.trim() : '';
+      const disambiguation = typeof row.disambiguation === 'string' ? row.disambiguation.trim() : '';
+      if (!id || !placeName) return null;
+      return { id, name: placeName, score, type, disambiguation };
+    })
+    .filter((item): item is MusicBrainzPlaceSearchResult => Boolean(item));
+}
+
+export async function resolveMusicBrainzStudioPlace(
+  studioName: string,
+  acceptedNames: string[] = []
+): Promise<MusicBrainzPlaceSearchResult | null> {
+  const base = studioName.trim();
+  if (!base) return null;
+
+  const queries = Array.from(
+    new Set(
+      [
+        base,
+        ...acceptedNames,
+        base.replace(/,\s*london$/i, ''),
+        base.replace(/,\s*stockholm$/i, ''),
+        base.replace(/,\s*los angeles$/i, ''),
+      ]
+        .map((value) => value.trim())
+        .filter(Boolean)
+    )
+  ).slice(0, 6);
+
+  const baseCanonical = normalizeStudioMatch(base);
+  let best: { candidate: MusicBrainzPlaceSearchResult; rank: number } | null = null;
+
+  for (const query of queries) {
+    let candidates: MusicBrainzPlaceSearchResult[] = [];
+    try {
+      candidates = await searchMusicBrainzPlacesByName(query, 8);
+    } catch {
+      candidates = [];
+    }
+
+    for (const candidate of candidates) {
+      const type = normalizeStudioType(candidate.type);
+      if (type && type !== 'studio') continue;
+
+      const candidateCanonical = normalizeStudioMatch(candidate.name);
+      if (!candidateCanonical) continue;
+
+      const exact = candidateCanonical === baseCanonical;
+      const includes = !exact && (candidateCanonical.includes(baseCanonical) || baseCanonical.includes(candidateCanonical));
+      const score = Number.isFinite(candidate.score) ? candidate.score : 0;
+      const rank = (exact ? 10000 : includes ? 7000 : 0) + score;
+
+      if (!best || rank > best.rank) {
+        best = { candidate, rank };
+      }
+    }
+
+    if (best && best.rank >= 10000) break;
+  }
+
+  return best?.candidate || null;
+}
+
+export async function fetchMusicBrainzStudioTracksByPlace(
+  placeMbid: string,
+  limit = 200
+): Promise<MusicBrainzStudioTrack[]> {
+  const mbid = placeMbid.trim();
+  if (!mbid) return [];
+
+  const safeLimit = Math.max(1, Math.min(2000, Math.floor(limit)));
+  const url = `${MUSICBRAINZ_BASE_URL}/place/${encodeURIComponent(mbid)}?inc=recording-rels+artist-credits&fmt=json`;
+  const raw = await rateLimitedFetchJson(url) as { relations?: unknown[] };
+  const relations = Array.isArray(raw.relations) ? raw.relations : [];
+
+  const dedupe = new Set<string>();
+  const output: MusicBrainzStudioTrack[] = [];
+
+  for (const relation of relations) {
+    if (!relation || typeof relation !== 'object') continue;
+    const row = relation as {
+      type?: unknown;
+      begin?: unknown;
+      end?: unknown;
+      ['target-type']?: unknown;
+      recording?: {
+        id?: unknown;
+        title?: unknown;
+        ['artist-credit']?: unknown;
+      };
+    };
+
+    const relationType = typeof row.type === 'string' ? row.type.trim().toLowerCase() : '';
+    const targetType = typeof row['target-type'] === 'string' ? row['target-type'].trim().toLowerCase() : '';
+    if (relationType !== 'recorded at' || targetType !== 'recording') continue;
+
+    const recording = row.recording;
+    const recordingMbid = typeof recording?.id === 'string' ? recording.id.trim() : '';
+    const title = typeof recording?.title === 'string' ? recording.title.trim() : '';
+    const artist = formatArtistCredit(recording?.['artist-credit']);
+    if (!recordingMbid || !title || !artist) continue;
+
+    const key = `${recordingMbid}::${artist.toLowerCase()}::${title.toLowerCase()}`;
+    if (dedupe.has(key)) continue;
+    dedupe.add(key);
+
+    const begin = typeof row.begin === 'string' && row.begin.trim().length > 0 ? row.begin.trim() : null;
+    const end = typeof row.end === 'string' && row.end.trim().length > 0 ? row.end.trim() : null;
+
+    output.push({
+      artist,
+      title,
+      recordingMbid,
+      relationType,
+      begin,
+      end,
+    });
+
+    if (output.length >= safeLimit) break;
+  }
+
+  return output;
 }
 
 export async function resolveMusicBrainzPerson(name: string): Promise<MusicBrainzArtistSearchResult | null> {

--- a/server/src/services/studio-identity.ts
+++ b/server/src/services/studio-identity.ts
@@ -6,6 +6,7 @@ export interface StudioIdentity {
   aliases: string[];
   successorNames: string[];
   discogsLabelId?: number;
+  musicBrainzPlaceId?: string;
   preferredArtists?: string[];
   activeStartYear?: number;
   activeEndYear?: number;
@@ -46,6 +47,19 @@ const STUDIO_IDENTITIES: StudioIdentity[] = [
     ],
     successorNames: [],
     discogsLabelId: 29092,
+    musicBrainzPlaceId: 'b7a2fdd6-0d78-463a-ba46-8514945d5f4d',
+    preferredArtists: [
+      'Kate Bush',
+      'Elton John',
+      'The Police',
+      'Dire Straits',
+      'Duran Duran',
+      'Mike Oldfield',
+      'Paul McCartney',
+      'George Michael',
+      'Phil Collins',
+      'Peter Gabriel',
+    ],
   },
   {
     key: 'gold_star_studios_los_angeles',
@@ -58,6 +72,20 @@ const STUDIO_IDENTITIES: StudioIdentity[] = [
     ],
     successorNames: [],
     discogsLabelId: 263247,
+    musicBrainzPlaceId: 'd1338bbb-12bb-44e9-810b-6e473ceda061',
+    preferredArtists: [
+      'The Ronettes',
+      'The Crystals',
+      'The Righteous Brothers',
+      'Darlene Love',
+      'The Beach Boys',
+      'Ike & Tina Turner',
+      'Sonny & Cher',
+      'Herb Alpert & The Tijuana Brass',
+      'Buffalo Springfield',
+      'Cher',
+      'Ritchie Valens',
+    ],
   },
   {
     key: 'polar_studios_stockholm',
@@ -70,6 +98,7 @@ const STUDIO_IDENTITIES: StudioIdentity[] = [
       'Polar Studios Stockholm',
     ],
     successorNames: [],
+    musicBrainzPlaceId: '2288e333-936b-4516-bdea-274934476caa',
     preferredArtists: [
       'ABBA',
       'Led Zeppelin',
@@ -157,6 +186,7 @@ export interface ResolvedStudioIdentity {
   acceptedStudioNames: string[];
   excludedSuccessorNames: string[];
   discogsLabelId?: number;
+  musicBrainzPlaceId?: string;
   preferredArtists: string[];
   activeStartYear?: number;
   activeEndYear?: number;
@@ -170,6 +200,7 @@ function toResolvedStudioIdentity(compiled: CompiledStudioIdentity): ResolvedStu
     acceptedStudioNames: [compiled.identity.primaryName, ...compiled.identity.aliases],
     excludedSuccessorNames: [...compiled.identity.successorNames],
     discogsLabelId: compiled.identity.discogsLabelId,
+    musicBrainzPlaceId: compiled.identity.musicBrainzPlaceId,
     preferredArtists: [...(compiled.identity.preferredArtists || [])],
     activeStartYear: compiled.identity.activeStartYear,
     activeEndYear: compiled.identity.activeEndYear,


### PR DESCRIPTION
## Summary

This PR switches studio evidence backfill to a MusicBrainz-first strategy (recording-level `recorded at` place relations), with Discogs as fallback for sparse cases.

It also adds studio-specific diversity/ranking guardrails to improve artist breadth while preserving strict recorded-at precision.

### What changed

- **MusicBrainz studio source added**
  - Added place search/resolve + place recording fetch in `server/src/services/musicbrainz.ts`
  - Uses `place -> recording-rels + artist-credits`, filtered to `recorded at`
- **Hybrid studio backfill**
  - `backfillStudioFromDiscogs` now runs as a hybrid orchestrator:
    - MusicBrainz primary
    - Discogs fallback when track/artist breadth is too low
  - Supports source-aware seeding (`musicbrainz` / `discogs`) and source-specific synthetic playlist rows
- **Trusted evidence widened**
  - Trusted studio evidence queries in `server/src/services/db.ts` now include:
    - `[system] studio evidence backfill from discogs :: ...`
    - `[system] studio evidence backfill from musicbrainz :: ...`
- **Studio identity enrichment**
  - Added `musicBrainzPlaceId` support in `server/src/services/studio-identity.ts`
  - Added known MBIDs for:
    - AIR Studios (Oxford-era entry)
    - Gold Star Studios
    - Polar Studios
  - Added/expanded preferred artists for AIR and Gold Star
- **Studio curation flow updates**
  - Added studio-specific artist diversity pass
  - Updated studio ranking heuristics to penalize obvious non-song/noisy entries
  - Kept strict recorded-at behavior and min-track safeguards

## Why

Discogs-only studio backfill often produced very narrow artist pools for some studios (e.g. AIR/Gold Star), causing poor variety even when enough tracks existed.

MusicBrainz has stronger recording→place coverage for studio relations, making it a better primary source for strict "recorded at" semantics.

## Validation

- `npm run build` ✅
- `npm run eval:parser:strict` ✅
- `npm run eval:routing:strict` ✅
- `npm run eval:studio-evidence:strict` ✅
- `npm run eval:atlas:strict` ✅

## Smoke checks

- Polar prompt still returns strict recorded-at set and >=8 floor (12 tracks)
- Gold Star now shows significantly improved artist variation (25 tracks / 25 unique artists in local smoke)

## Known follow-up

- AIR quality still needs an additional pass for stronger “megaklassiker” prioritization.
  - Variation is now improved, but top picks can still skew niche due to source noise.
  - This should be a focused follow-up PR (quality ranking filters + mainstream weighting for studio mode).